### PR TITLE
Support variable time signatures

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -334,6 +334,18 @@ section h2 {
     box-shadow: 0 1px 3px rgba(0,0,0,0.2);
 }
 
+.measure-time-sig {
+    position: absolute;
+    top: -10px;
+    right: 8px;
+    background: #6c757d;
+    color: #fff;
+    font-size: 0.75rem;
+    padding: 3px 8px;
+    border-radius: 4px;
+    box-shadow: 0 1px 3px rgba(0,0,0,0.2);
+}
+
 .measure.current-measure .measure-number {
     background: #007bff;
     box-shadow: 0 2px 6px rgba(0,123,255,0.3);


### PR DESCRIPTION
## Summary
- allow each measure to store its own time signature
- parse time signature tokens during chord entry
- group chords into measures using per-measure time signatures
- show time signature changes in the progression display
- update utilities like deletion, navigation and measure creation
- style time signature labels

## Testing
- `npm test` *(fails: `open` not found)*

------
https://chatgpt.com/codex/tasks/task_e_686db075d3088324b60ca51eec68c281