### PR TITLE
Add metronome toggle and accented downbeat

### DIFF
--- a/index.html
+++ b/index.html
@@ -50,6 +50,9 @@
                             <input type="checkbox" id="loop" checked> Loop Mode
                         </label>
                     </div>
+                    <div class="control-group">
+                        <label><input type="checkbox" id="metronome-toggle" checked> Metronome Click</label>
+                    </div>
                 </div>
             </section>
 

--- a/script.js
+++ b/script.js
@@ -103,6 +103,11 @@ class MusicalAccompanist {
             this.loopMode = e.target.checked;
         });
 
+        document.getElementById('metronome-toggle').addEventListener('change', (e) => {
+            this.metronomeEnabled = e.target.checked;
+            this.showStatus(`Metronome ${this.metronomeEnabled ? 'On' : 'Off'}`);
+        });
+
         // Playback controls
         document.getElementById('play-btn').addEventListener('click', () => {
             this.startPlayback();
@@ -1191,8 +1196,9 @@ class MusicalAccompanist {
      */
     playMetronome() {
         if (!this.metronome) return;
-        
-        this.metronome.triggerAttackRelease('C6', '32n');
+        const isDownbeat = (this.currentChordIndex % this.timeSignature === 0);
+        const pitch = isDownbeat ? 'C5' : 'C6';
+        this.metronome.triggerAttackRelease(pitch, '32n');
     }
 
     /**


### PR DESCRIPTION
## Summary
- add metronome click checkbox to the control panel
- allow toggling metronome on/off via UI and status message
- accent the first beat of each measure with a lower pitch

## Testing
- `npm test` *(fails: `open` not found)*

------
https://chatgpt.com/codex/tasks/task_e_686db04ca45083248e88ab0f15feb0b9