### PR TITLE
Add key signature and Roman numeral analysis

### DIFF
--- a/index.html
+++ b/index.html
@@ -50,6 +50,27 @@
                             <input type="checkbox" id="loop" checked> Loop Mode
                         </label>
                     </div>
+                    <div class="control-group">
+                        <label>Key Signature:</label>
+                        <select id="key-tonic">
+                            <option value="C">C</option>
+                            <option value="C#">C♯/D♭</option>
+                            <option value="D">D</option>
+                            <option value="D#">D♯/E♭</option>
+                            <option value="E">E</option>
+                            <option value="F">F</option>
+                            <option value="F#">F♯/G♭</option>
+                            <option value="G">G</option>
+                            <option value="G#">G♯/A♭</option>
+                            <option value="A">A</option>
+                            <option value="A#">A♯/B♭</option>
+                            <option value="B">B</option>
+                        </select>
+                        <select id="key-mode">
+                            <option value="major" selected>Major</option>
+                            <option value="minor">Minor</option>
+                        </select>
+                    </div>
                 </div>
             </section>
 


### PR DESCRIPTION
## Summary
- add UI controls for key signature selection
- handle key state in script
- parse roman numeral and scale degree chords
- compute Roman numeral analysis display

## Testing
- `npm test` *(fails: `open` not found and no network)*

------
https://chatgpt.com/codex/tasks/task_e_686db06a7c3083248474ab77819ffd90