### PR TITLE
List individual tonic options in key selector

### DIFF
--- a/index.html
+++ b/index.html
@@ -56,18 +56,27 @@
                     <div class="control-group">
                         <label>Key Signature:</label>
                         <select id="key-tonic">
+                            <option value="Cb">C♭</option>
                             <option value="C">C</option>
-                            <option value="C#">C♯/D♭</option>
+                            <option value="C#">C♯</option>
+                            <option value="Db">D♭</option>
                             <option value="D">D</option>
-                            <option value="D#">D♯/E♭</option>
+                            <option value="D#">D♯</option>
+                            <option value="Eb">E♭</option>
                             <option value="E">E</option>
+                            <option value="E#">E♯</option>
+                            <option value="Fb">F♭</option>
                             <option value="F">F</option>
-                            <option value="F#">F♯/G♭</option>
+                            <option value="F#">F♯</option>
+                            <option value="Gb">G♭</option>
                             <option value="G">G</option>
-                            <option value="G#">G♯/A♭</option>
+                            <option value="G#">G♯</option>
+                            <option value="Ab">A♭</option>
                             <option value="A">A</option>
-                            <option value="A#">A♯/B♭</option>
+                            <option value="A#">A♯</option>
+                            <option value="Bb">B♭</option>
                             <option value="B">B</option>
+                            <option value="B#">B♯</option>
                         </select>
                         <select id="key-mode">
                             <option value="major" selected>Major</option>

--- a/public/index.html
+++ b/public/index.html
@@ -56,18 +56,27 @@
                     <div class="control-group">
                         <label>Key Signature:</label>
                         <select id="key-tonic">
+                            <option value="Cb">C♭</option>
                             <option value="C">C</option>
-                            <option value="C#">C♯/D♭</option>
+                            <option value="C#">C♯</option>
+                            <option value="Db">D♭</option>
                             <option value="D">D</option>
-                            <option value="D#">D♯/E♭</option>
+                            <option value="D#">D♯</option>
+                            <option value="Eb">E♭</option>
                             <option value="E">E</option>
+                            <option value="E#">E♯</option>
+                            <option value="Fb">F♭</option>
                             <option value="F">F</option>
-                            <option value="F#">F♯/G♭</option>
+                            <option value="F#">F♯</option>
+                            <option value="Gb">G♭</option>
                             <option value="G">G</option>
-                            <option value="G#">G♯/A♭</option>
+                            <option value="G#">G♯</option>
+                            <option value="Ab">A♭</option>
                             <option value="A">A</option>
-                            <option value="A#">A♯/B♭</option>
+                            <option value="A#">A♯</option>
+                            <option value="Bb">B♭</option>
                             <option value="B">B</option>
+                            <option value="B#">B♯</option>
                         </select>
                         <select id="key-mode">
                             <option value="major" selected>Major</option>


### PR DESCRIPTION
## Summary
- Expand `key-tonic` dropdown to include every tonic name individually
- Display Unicode sharp and flat symbols for tonic labels

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a63bb56f608324b7bbcc5cf721ecae